### PR TITLE
fixed - link copies as full URL

### DIFF
--- a/src/app/components/MasjidModal.tsx
+++ b/src/app/components/MasjidModal.tsx
@@ -35,7 +35,8 @@ const MasjidModal = ({ masjid, isOpen, onClose }: MasjidModalProps) => {
   const copyShareLink = async () => {
     const link = generateShareLink();
     try {
-      await navigator.clipboard.writeText(link);
+      const encodedLink = encodeURI(link); //helps copy as an proper link you can paste on WhatsApp
+      await navigator.clipboard.writeText(encodedLink);
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000);
     } catch (err) {


### PR DESCRIPTION
<img width="865" height="781" alt="image" src="https://github.com/user-attachments/assets/ac8045b0-ecbf-41b8-b7bb-91d49684c65c" />
When trying to copy the link, it looks like this
https://hk-masjid-prayer-times.vercel.app/masjids/Kowloon Mosque and Islamic Centre

this is an issue as WhatsApp does not see it as a URL because of the spaces in between the name of the mosques

Now with this change it copies the link properly and when you paste it, it looks like this
http://localhost:3000/masjids/Kowloon%20Mosque%20and%20Islamic%20Centre